### PR TITLE
Don't crash on pre iOS 5

### DIFF
--- a/DAKeyboardControl/DAKeyboardControlScrollView.m
+++ b/DAKeyboardControl/DAKeyboardControlScrollView.m
@@ -50,7 +50,9 @@
                                                    object:nil];
         
         // Register for gesture recognizer calls
-        [self.panGestureRecognizer addTarget:self action:@selector(panGestureDidChange)];
+        if ([self respondsToSelector:@selector(panGestureRecognizer)]) {
+            [self.panGestureRecognizer addTarget:self action:@selector(panGestureDidChange)];
+        }
     }
     else
     {
@@ -78,7 +80,9 @@
                                                       object:nil];
         
         // Unregister for gesture recognizer calls
-        [self.panGestureRecognizer removeTarget:self action:@selector(panGestureDidChange)];
+        if ([self respondsToSelector:@selector(panGestureRecognizer)]) {
+            [self.panGestureRecognizer removeTarget:self action:@selector(panGestureDidChange)];
+        }
     }
 }
 

--- a/DAKeyboardControl/DAKeyboardControlTableView.m
+++ b/DAKeyboardControl/DAKeyboardControlTableView.m
@@ -50,7 +50,9 @@
                                                    object:nil];
         
         // Register for gesture recognizer calls
-        [self.panGestureRecognizer addTarget:self action:@selector(panGestureDidChange)];
+        if ([self respondsToSelector:@selector(panGestureRecognizer)]) {
+            [self.panGestureRecognizer addTarget:self action:@selector(panGestureDidChange)];
+        }
     }
     else
     {
@@ -78,7 +80,9 @@
                                                       object:nil];
         
         // Unregister for gesture recognizer calls
-        [self.panGestureRecognizer removeTarget:self action:@selector(panGestureDidChange)];
+        if ([self respondsToSelector:@selector(panGestureRecognizer)]) {
+            [self.panGestureRecognizer removeTarget:self action:@selector(panGestureDidChange)];
+        }
     }
 }
 


### PR DESCRIPTION
This allows the keyboard control classes to run on iOS 4.2 and later, maybe
older.  The swiping doesn't actually work for pre iOS 5, but it also doesn't
crash so an app can support swipe down keyboard and old hardware.
