### PR TITLE
Add new public method: hideKeyboard

### DIFF
--- a/DAKeyboardControl/DAKeyboardControl.h
+++ b/DAKeyboardControl/DAKeyboardControl.h
@@ -21,4 +21,6 @@ typedef void (^DAKeyboardDidMoveBlock)(CGRect keyboardFrameInView);
 
 - (CGRect)keyboardFrameInView;
 
+- (void)hideKeyboard;
+
 @end

--- a/DAKeyboardControl/DAKeyboardControl.m
+++ b/DAKeyboardControl/DAKeyboardControl.m
@@ -154,6 +154,13 @@ static char UIViewKeyboardPanRecognizer;
     self.keyboardPanRecognizer = nil;
 }
 
+- (void)hideKeyboard
+{
+    self.keyboardActiveView.hidden = YES;
+    self.keyboardActiveView.userInteractionEnabled = NO;
+    [self.keyboardActiveInput resignFirstResponder];
+}
+
 #pragma mark - Input Notifications
 
 - (void)responderDidBecomeActive:(NSNotification *)notification
@@ -364,9 +371,7 @@ static char UIViewKeyboardPanRecognizer;
                              completion:^(BOOL finished){
                                  if (!within44Pixels)
                                  {
-                                     self.keyboardActiveView.hidden = YES;
-                                     self.keyboardActiveView.userInteractionEnabled = NO;
-                                     [self.keyboardActiveInput resignFirstResponder];
+                                     [self hideKeyboard];
                                  }
                              }];
         }
@@ -392,9 +397,7 @@ static char UIViewKeyboardPanRecognizer;
                              completion:^(BOOL finished){
                                  if (!within44Pixels)
                                  {
-                                     self.keyboardActiveView.hidden = YES;
-                                     self.keyboardActiveView.userInteractionEnabled = NO;
-                                     [self.keyboardActiveInput resignFirstResponder];
+                                     [self hideKeyboard];
                                  }
                              }];
         }


### PR DESCRIPTION
I have found that when I was using DAKeyboardControl
I have wanted to programmatically hide the keyboard 
created by DAKeyboardControl.

This commit adds a public method to the category,
allowing you to send a message to the receiving UIView
to hide the keyboard.

I have also replaced the occurrences in the code 
that were hiding the keyboard to use the new public method.
