### PR TITLE
Keyboard isn't re-anabled correclty

### DIFF
--- a/DAKeyboardControl/DAKeyboardControl.m
+++ b/DAKeyboardControl/DAKeyboardControl.m
@@ -460,6 +460,7 @@ static char UIViewKeyboardPanRecognizer;
                                  */
                              }
                              completion:^(BOOL finished){
+                                 [[self keyboardActiveView] setUserInteractionEnabled:!shouldRecede];
                                  if (shouldRecede)
                                  {
                                      [self hideKeyboard];


### PR DESCRIPTION
When panning down and than up and release your finger before the keyboard is fully up again, the keyboard isn't enabled again.

The attached commit enables the keyboard when the pangesture is finished of cancelled and the keyboard isn't hidden.
