### PR TITLE
Sets the maximumNumberOfTouches on the panGestureRecognizer to be as man...

### DIFF
--- a/DAKeyboardControl/DAKeyboardControl.m
+++ b/DAKeyboardControl/DAKeyboardControl.m
@@ -399,7 +399,9 @@ static char UIViewKeyboardPanRecognizer;
     {
         case UIGestureRecognizerStateBegan:
         {
-            
+            // For the duration of this gesture, do not recognize more touches than
+            // it started with
+            gesture.maximumNumberOfTouches = gesture.numberOfTouches;
         }
             break;
         case UIGestureRecognizerStateChanged:
@@ -466,6 +468,9 @@ static char UIViewKeyboardPanRecognizer;
                                      [self hideKeyboard];
                                  }
                              }];
+            
+            // Set the max number of touches back to the default
+            gesture.maximumNumberOfTouches = NSUIntegerMax;
         }
             break;
         default:


### PR DESCRIPTION
Sets the maximumNumberOfTouches on the panGestureRecognizer to be as many touches as the gesture started with for the duration of the gesture.

This fixes a problem where the keyboard jumps around erratically if you start panning down to dismiss with one finger, and then touch the keyboard with a 2nd finger as it is being scrolled off the screen.
