### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ self.view.keyboardTriggerOffset = 44.0f;	// Input view frame height
 [self.view hideKeyboard];
 ```
 
+### Remove the NSNotification observer at the end of a VC's life (convenience method)
+
+```objective-c
+[self.view removeKeyboardControl];
+```
+
 ## Notes
 
 ### Tested in App Store!


### PR DESCRIPTION
Added one more example to show the user how to remove the observer. This method is super helpful for apps where the DAKeyboardControl is used on various different screens, including standard VCs, modals, SVCs, etc.
