### PR TITLE
Support for "snapping" to the bottom of a scroll view

### DIFF
--- a/DAKeyboardControl/DAKeyboardControl.h
+++ b/DAKeyboardControl/DAKeyboardControl.h
@@ -13,6 +13,7 @@ typedef void (^DAKeyboardDidMoveBlock)(CGRect keyboardFrameInView);
 @interface UIView (DAKeyboardControl)
 
 @property (nonatomic) CGFloat keyboardTriggerOffset;
+@property (nonatomic, readonly) BOOL keyboardWillRecede;
 
 - (void)addKeyboardPanningWithActionHandler:(DAKeyboardDidMoveBlock)didMoveBlock;
 - (void)addKeyboardNonpanningWithActionHandler:(DAKeyboardDidMoveBlock)didMoveBlock;

--- a/DAKeyboardControl/DAKeyboardControl.m
+++ b/DAKeyboardControl/DAKeyboardControl.m
@@ -649,4 +649,16 @@ static BOOL isPanning;
     [self didChangeValueForKey:@"keyboardPanRecognizer"];
 }
 
+- (BOOL)keyboardWillRecede
+{
+    CGFloat keyboardViewHeight = self.keyboardActiveView.bounds.size.height;
+    CGFloat keyboardWindowHeight = self.keyboardActiveView.window.bounds.size.height;
+    CGPoint touchLocationInKeyboardWindow = [self.keyboardPanRecognizer locationInView:self.keyboardActiveView.window];
+    
+    CGFloat thresholdHeight = keyboardWindowHeight - keyboardViewHeight - self.keyboardTriggerOffset + 44.0f;
+    CGPoint velocity = [self.keyboardPanRecognizer velocityInView:self.keyboardActiveView];
+    
+    return touchLocationInKeyboardWindow.y >= thresholdHeight && velocity.y >= 0;
+}
+
 @end


### PR DESCRIPTION
`keyboardWillRecede` indicates that, if the user was to lift their finger at that moment, whether it would cause the keyboard to be dismissed. This is helpful when combined with `-[UIScrollView scrollViewWillEndDragging:withVelocity:targetContentOffset:targetContentOffset]`. Because this method usually gets called before the keyboard control's methods, we need to calculate it then. You can then do the following to snap the scrollView back to the bottom (iMessages does this).

```
- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset
{
    if (self.view.keyboardWillRecede && velocity.y > -1.0 && velocity.y < 0.0) {
        targetContentOffset->y = scrollView.contentSize.height - scrollView.bounds.size.height;
    }
}
```

For an even closer implementation, add an _startedAtBottom instance variable and use the following:

```
- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView
{
    _startedAtBottom = scrollView.contentOffset.y == scrollView.contentSize.height - scrollView.bounds.size.height;
}

- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset
{
    if (_startedAtBottom && self.view.keyboardWillRecede && velocity.y > -1.0 && velocity.y < 0.0) {
        targetContentOffset->y = scrollView.contentSize.height - scrollView.bounds.size.height;
    }
}
```

That will make is so that it only snaps to the bottom if it started out there when the user started to hide the keyboard.
