### PR TITLE
Fixed missing newline at the end of the header

### DIFF
--- a/DAKeyboardControl/DAKeyboardControl.h
+++ b/DAKeyboardControl/DAKeyboardControl.h
@@ -25,3 +25,4 @@ typedef void (^DAKeyboardDidMoveBlock)(CGRect keyboardFrameInView);
 - (void)hideKeyboard;
 
 @end
+


### PR DESCRIPTION
The header was missing a newline at the end and this caused problems with GCC_WARN_ABOUT_MISSING_NEWLINE. Because it was in the header CocoaPods' inhibit flags didn't help.
