### PR TITLE
Fix multiple recognizers being added to view

### DIFF
--- a/DAKeyboardControl/DAKeyboardControl.m
+++ b/DAKeyboardControl/DAKeyboardControl.m
@@ -247,7 +247,7 @@ static char UIViewIsPanning;
                              self.keyboardDidMoveBlock(keyboardEndFrameView);
                      }
                      completion:^(BOOL finished){
-                         if (self.panning)
+                         if (self.panning && !self.keyboardPanRecognizer)
                          {
                              // Register for gesture recognizer calls
                              self.keyboardPanRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self
@@ -326,6 +326,7 @@ static char UIViewIsPanning;
                      completion:^(BOOL finished){
                          // Remove gesture recognizer when keyboard is not showing
                          [self removeGestureRecognizer:self.keyboardPanRecognizer];
+                         self.keyboardPanRecognizer = nil;
                      }];
 }
 


### PR DESCRIPTION
When the user switches directly from one text field to another, it is possible that `inputKeyboardWillShow` and `inputKeyboardDidShow` are called without `inputKeyboardWillHide` and `inputKeyboardDidHide` called in between.

This caused DAKeyboardControl to add multiple gesture recognizers to the view, loosing references to any but the last. That led to eg. UIScrollViews not working properly after dismissal of the Keyboard.

This pull request fixes that issue.
