### PR TITLE
Fixed iOS 7 keyboard animation curve issue

### DIFF
--- a/DAKeyboardControl/DAKeyboardControl.m
+++ b/DAKeyboardControl/DAKeyboardControl.m
@@ -12,24 +12,7 @@
 
 static inline UIViewAnimationOptions AnimationOptionsForCurve(UIViewAnimationCurve curve)
 {
-	switch (curve) {
-		case UIViewAnimationCurveEaseInOut:
-			return UIViewAnimationOptionCurveEaseInOut;
-			break;
-		case UIViewAnimationCurveEaseIn:
-			return UIViewAnimationOptionCurveEaseIn;
-			break;
-		case UIViewAnimationCurveEaseOut:
-			return UIViewAnimationOptionCurveEaseOut;
-			break;
-		case UIViewAnimationCurveLinear:
-			return UIViewAnimationOptionCurveLinear;
-			break;
-			
-		default:
-			return UIViewAnimationOptionCurveEaseInOut;
-			break;
-	}
+	return curve << 16;
 }
 
 static char UIViewKeyboardTriggerOffset;


### PR DESCRIPTION
The animation curve (UIViewAnimationCurve) used for the iOS 7 keyboard has no representation in UIViewAnimationOptions. This leads to the keyboard beeing animated in a different style than the views in the addKeyboardPanningWithActionHandler-block. Just shifting bits instead of doing a switch solves the problem.
