### PR TITLE
Only inject inputAccessoryView if textView isEditable.

### DIFF
--- a/DAKeyboardControl/DAKeyboardControl.m
+++ b/DAKeyboardControl/DAKeyboardControl.m
@@ -566,7 +566,7 @@ static char UIViewKeyboardOpened;
         }
         else if ([subview isKindOfClass:[UITextView class]]) {
             UITextView *textView = (UITextView *)subview;
-            if ([textView respondsToSelector:@selector(setInputAccessoryView:)] && [textView respondsToSelector:@selector(editable)] && textView.editable)
+            if ([textView respondsToSelector:@selector(setInputAccessoryView:)] && [textView respondsToSelector:@selector(isEditable)] && textView.isEditable)
             {
                 UIView *nullView = [[UIView alloc] initWithFrame:CGRectZero];
                 nullView.backgroundColor = [UIColor clearColor];


### PR DESCRIPTION
There's a bug in UIKit that would fire a `UIKeyboard(Will|Did)ShowNotification` when a `UITextView` is readonly (`textView.editable = NO;`) but has a `inputAccessoryView`. See also: http://openradar.appspot.com/radar?id=5306932189462528

To work around this issue, `DAKeyboardControl` should only inject a `inputAccessoryView` if the `UITextView` actually `isEditable`.
